### PR TITLE
Improve calendar time scale and overlapping blocks

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,15 +25,19 @@ aside { display: flex; flex-direction: column; gap: 16px; }
 .calBody { height: calc(100vh - 210px); overflow: auto; position: relative; }
 
 .timeCol { background: #f9fafb; border-right: 1px solid #e5e7eb; }
-.timeLabel { height: 60px; padding: 2px 6px; font-size: 0.8rem; color: #6b7280; border-bottom: 1px dashed #eee; }
+.timeLabel { height: 120px; padding: 2px 6px; font-size: 0.8rem; color: #6b7280; border-bottom: 1px dashed #eee; }
 
 .dayCol.day { position: relative; border-right: 1px solid #f1f5f9; }
 .dayCol.day::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 100%; background-image: linear-gradient(to bottom, rgba(0,0,0,0.04) 1px, transparent 1px); background-size: 100% 30px; pointer-events: none; }
 .dayCol.day:last-child { border-right: none; }
 
-.block { position: absolute; left: 6px; right: 6px; border-radius: 6px; color: #111; padding: 6px; font-size: 0.85rem; border: 1px solid rgba(0,0,0,0.1); box-shadow: 0 1px 2px rgba(0,0,0,0.06); overflow: hidden; cursor: pointer; }
+.block { position: absolute; left: 6px; width: calc(100% - 12px); border-radius: 6px; color: #111; padding: 6px; font-size: 0.85rem; border: 1px solid rgba(0,0,0,0.1); box-shadow: 0 1px 2px rgba(0,0,0,0.06); overflow: auto; cursor: pointer; opacity: 0.9; }
 .block .title { font-weight: 700; }
 .block .meta { font-size: 0.75rem; opacity: 0.9; }
+
+#summary { max-height: 200px; overflow: auto; }
+.groupTotals { margin-top: 8px; }
+.groupTotals div { display: flex; justify-content: space-between; }
 
 .modal { position: fixed; inset: 0; background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; padding: 16px; }
 .modal.hidden { display: none; }


### PR DESCRIPTION
## Summary
- Fix time column height so labels match block positions
- Arrange overlapping blocks side-by-side with slight transparency
- Display per-category weekly totals and add scrolling to prevent overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896654c73988331b58229f31f495274