### PR TITLE
Add 24h scheduling, group editing, and zoom

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -8,12 +8,13 @@ How to use
 3) Use categories to color-code (Sleep, Work, Children, Commute, Training, etc.).
 4) Mark “Core work” vs “Alternative focus” for attention-appropriate work.
 5) The left panel shows totals (hours) per category per day and your weekly total.
-6) Set day start/end hours and your weekly work target in Settings.
+6) Use the Zoom control to adjust the vertical scale. Set day start/end hours and your weekly work target in Settings.
 7) Data is saved locally in your browser (no server). Export/Import JSON to back up.
 
 Notes
 -----
-- Grid density: each hour is 60px tall; each minute equals 1px * 2 (i.e., 2px/min); background lines every 30 minutes.
+- Grid density is adjustable via the Zoom control (minutes per pixel) so you can fit the whole day on screen if desired.
+- Times use a 24-hour clock and blocks stay within a single day (00:00–24:00).
 - Overlaps are allowed; blocks display stacked in the same column.
 - You can click a block to edit or delete.
 - This is a client-only app—feel free to host it anywhere (GitHub Pages, Netlify, local).

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
       Import JSON <input type="file" id="importInput" accept="application/json">
     </label>
     <button id="clearBtn">Clear All</button>
+    <label class="zoomLabel">Zoom <input type="range" id="zoomRange" min="0.25" max="4" step="0.25"></label>
+    <button id="fitDayBtn">Fit Day</button>
   </div>
 </header>
 
@@ -108,11 +110,11 @@
       <div class="row two">
         <div>
           <label>Start</label>
-          <input type="time" id="startInput" step="900" required>
+          <input type="time" id="startInput" step="900" min="00:00" max="24:00" required>
         </div>
         <div>
           <label>End</label>
-          <input type="time" id="endInput" step="900" required>
+          <input type="time" id="endInput" step="900" min="00:00" max="24:00" required>
         </div>
       </div>
       <div class="row flags">

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,8 @@ html, body { margin: 0; padding: 0; font-family: system-ui, -apple-system, Segoe
 header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #fff; border-bottom: 1px solid #e5e7eb; position: sticky; top: 0; z-index: 10; }
 header h1 { margin: 0; font-size: 1.2rem; }
 .controls button, .controls label { margin-right: 8px; }
+.controls .zoomLabel { display: inline-flex; align-items: center; gap: 4px; }
+.controls .zoomLabel input { width: 80px; }
 button { background: #111827; color: #fff; border: none; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
 button:hover { opacity: 0.9; }
 button.danger { background: #dc2626; }


### PR DESCRIPTION
## Summary
- allow scheduling from 00:00 to 24:00 with validation preventing cross-day blocks
- support editing multi-day blocks by updating all grouped days at once
- add vertical zoom control and fit-day button to view entire day

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68966d2bb69c83318f1f7ae383bfe139