### PR TITLE
fix: enforce 24h time inputs on Safari

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,10 +29,23 @@ function init() {
   renderTimeColumn();
   renderDays();
   setupModals();
+  force24HourTimeInputs();
   syncSettingsUI();
   updateSummary();
   renderBlocks();
   bindControls();
+}
+
+function force24HourTimeInputs() {
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  if (isSafari) {
+    $$('#blockForm input[type="time"]').forEach(inp => {
+      inp.type = 'text';
+      inp.placeholder = 'HH:MM';
+      inp.pattern = '([01]\\d|2[0-3]):[0-5]\\d';
+      inp.setAttribute('inputmode', 'numeric');
+    });
+  }
 }
 
 function loadState() {


### PR DESCRIPTION
## Summary
- force Safari to show 24h times by converting `<input type="time">` to text fields with `HH:MM` pattern

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ab31c3dc8331bc1b41c12ae67c7a