### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,8 @@
 html, body { margin: 0; padding: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: #111; background: #fafafa; }
 header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #fff; border-bottom: 1px solid #e5e7eb; position: sticky; top: 0; z-index: 10; }
 header h1 { margin: 0; font-size: 1.2rem; }
-.controls button, .controls label { margin-right: 8px; }
+.controls { display: flex; flex-wrap: wrap; gap: 8px; }
+.controls button, .controls label { margin-right: 0; }
 .controls .zoomLabel { display: inline-flex; align-items: center; gap: 4px; }
 .controls .zoomLabel input { width: 80px; }
 button { background: #111827; color: #fff; border: none; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
@@ -20,11 +21,11 @@ aside { display: flex; flex-direction: column; gap: 16px; }
 .progressOuter { width: 100%; height: 12px; background: #e5e7eb; border-radius: 999px; overflow: hidden; margin: 4px 0 8px; }
 .progressInner { height: 100%; width: 0%; background: #10b981; transition: width 0.3s; }
 
-.calendarWrap { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; overflow: hidden; }
-.calHeader, .calBody { display: grid; grid-template-columns: 70px repeat(7, 1fr); }
+.calendarWrap { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; overflow: auto; }
+.calHeader, .calBody { display: grid; grid-template-columns: 70px repeat(7, minmax(120px, 1fr)); }
 .calHeader { background: #f9fafb; border-bottom: 1px solid #e5e7eb; }
 .calHeader .dayCol, .calHeader .timeCol { padding: 8px; font-weight: 600; text-align: center; }
-.calBody { height: calc(100vh - 210px); overflow: auto; position: relative; }
+.calBody { height: calc(100vh - 210px); overflow-y: auto; overflow-x: hidden; position: relative; }
 
 .timeCol { background: #f9fafb; border-right: 1px solid #e5e7eb; }
 .timeLabel { height: 120px; padding: 2px 6px; font-size: 0.8rem; color: #6b7280; border-bottom: 1px dashed #eee; }
@@ -61,4 +62,13 @@ footer { text-align: center; color: #6b7280; padding: 10px; font-size: 0.85rem; 
   main { grid-template-columns: 1fr; }
   aside { order: 2; }
   .calendarWrap { order: 1; }
+}
+
+@media (max-width: 600px) {
+  header { flex-direction: column; align-items: flex-start; justify-content: flex-start; }
+  header h1 { margin-bottom: 8px; }
+  .controls { width: 100%; }
+  .controls button, .controls label { flex: 1 1 calc(50% - 8px); }
+  main { padding: 8px; }
+  .calHeader, .calBody { grid-template-columns: 60px repeat(7, minmax(100px, 1fr)); }
 }


### PR DESCRIPTION
## Summary
- Enable flexible wrapping of header controls to avoid overflow on narrow viewports
- Allow horizontal scrolling of the calendar with minimum column widths for day columns
- Add mobile-specific media queries to stack the header and size controls for small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ab59f9c0833193abeca881488057