### PR TITLE
Allow entering 24:00 as end time

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,12 +37,14 @@ function init() {
 }
 
 function force24HourTimeInputs() {
-  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-  if (isSafari) {
+  const test = document.createElement('input');
+  test.type = 'time';
+  test.value = '24:00';
+  if (test.value !== '24:00') {
     $$('#blockForm input[type="time"]').forEach(inp => {
       inp.type = 'text';
       inp.placeholder = 'HH:MM';
-      inp.pattern = '([01]\\d|2[0-3]):[0-5]\\d';
+      inp.pattern = '((?:[01]\\d|2[0-3]):[0-5]\\d|24:00)';
       inp.setAttribute('inputmode', 'numeric');
     });
   }
@@ -204,6 +206,11 @@ function openBlockModal(prefill = null, blockId = null, groupId = null) {
 function onSaveBlock(e) {
   e.preventDefault();
   const modal = $("#blockModal");
+  const form = $("#blockForm");
+  if (!form.checkValidity()) {
+    form.reportValidity();
+    return;
+  }
   const editId = modal.dataset.editId;
   const groupId = modal.dataset.groupId || editId || cryptoId();
   const title = $("#titleInput").value.trim();


### PR DESCRIPTION
## Summary
- Allow time inputs to accept 24:00 by converting unsupported `time` inputs to text with a pattern that includes 24:00.
- Validate block form against the new time pattern before saving.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc34f4108331889f32c869e84648