### PR TITLE
Rebrand to Plan MyWeek with simplified styling

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,7 @@
-Weekly Planner — Calendar + Totals
-===================================
+Plan MyWeek
+===========
+
+Part of the MyWeek suite alongside upcoming Track MyWeek and Optimize MyWeek apps.
 
 How to use
 ----------

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-// Weekly Planner — Vanilla JS
+// Plan MyWeek — Vanilla JS
 const $ = (sel, root = document) => root.querySelector(sel);
 const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
 

--- a/index.html
+++ b/index.html
@@ -3,12 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Weekly Planner — Calendar + Totals</title>
+  <title>Plan MyWeek</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <header>
-  <h1>Weekly Planner</h1>
+  <h1>Plan MyWeek</h1>
   <div class="controls">
     <button id="addBlockBtn">+ Add Block</button>
     <button id="categoriesBtn">Categories</button>

--- a/styles.css
+++ b/styles.css
@@ -1,33 +1,104 @@
 * { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; color: #111; background: #fafafa; }
-header { display: flex; justify-content: space-between; align-items: center; padding: 12px 16px; background: #fff; border-bottom: 1px solid #e5e7eb; position: sticky; top: 0; z-index: 10; }
-header h1 { margin: 0; font-size: 1.2rem; }
+:root {
+  --primary: #2563eb;
+  --text: #1f2937;
+  --bg: #f3f4f6;
+  --surface: #ffffff;
+  --danger: #dc2626;
+}
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid #e5e7eb;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+header h1 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--primary);
+}
 .controls { display: flex; flex-wrap: wrap; gap: 8px; }
 .controls button, .controls label { margin-right: 0; }
 .controls .zoomLabel { display: inline-flex; align-items: center; gap: 4px; }
 .controls .zoomLabel input { width: 80px; }
-button { background: #111827; color: #fff; border: none; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
+button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
 button:hover { opacity: 0.9; }
-button.danger { background: #dc2626; }
-.importLabel { display: inline-flex; align-items: center; gap: 6px; background: #374151; color: #fff; padding: 8px 12px; border-radius: 6px; cursor: pointer; }
+button.danger { background: var(--danger); }
+.importLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--primary);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
 .importLabel input { display: none; }
 
 main { display: grid; grid-template-columns: 320px 1fr; gap: 16px; padding: 16px; }
 aside { display: flex; flex-direction: column; gap: 16px; }
-.panel { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; }
+.panel {
+  background: var(--surface);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+}
 .panel.note ul { margin: 8px 0 0 20px; }
 .targetRow { display: flex; justify-content: space-between; margin-bottom: 6px; }
 .targetRow.small { font-size: 0.9rem; color: #374151; }
-.progressOuter { width: 100%; height: 12px; background: #e5e7eb; border-radius: 999px; overflow: hidden; margin: 4px 0 8px; }
-.progressInner { height: 100%; width: 0%; background: #10b981; transition: width 0.3s; }
+.progressOuter {
+  width: 100%;
+  height: 12px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 4px 0 8px;
+}
+.progressInner {
+  height: 100%;
+  width: 0%;
+  background: var(--primary);
+  transition: width 0.3s;
+}
 
-.calendarWrap { background: #fff; border: 1px solid #e5e7eb; border-radius: 8px; overflow: auto; }
+.calendarWrap {
+  background: var(--surface);
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: auto;
+}
 .calHeader, .calBody { display: grid; grid-template-columns: 70px repeat(7, minmax(120px, 1fr)); }
-.calHeader { background: #f9fafb; border-bottom: 1px solid #e5e7eb; }
+.calHeader {
+  background: var(--bg);
+  border-bottom: 1px solid #e5e7eb;
+}
 .calHeader .dayCol, .calHeader .timeCol { padding: 8px; font-weight: 600; text-align: center; }
 .calBody { height: calc(100vh - 210px); overflow-y: auto; overflow-x: hidden; position: relative; }
 
-.timeCol { background: #f9fafb; border-right: 1px solid #e5e7eb; }
+.timeCol {
+  background: var(--bg);
+  border-right: 1px solid #e5e7eb;
+}
 .timeLabel { height: 120px; padding: 2px 6px; font-size: 0.8rem; color: #6b7280; border-bottom: 1px dashed #eee; }
 
 .dayCol.day { position: relative; border-right: 1px solid #f1f5f9; }


### PR DESCRIPTION
## Summary
- Rename Weekly Planner to **Plan MyWeek** and introduce new font and header
- Style overhaul using Inter font and branded color palette
- Update README with MyWeek suite description

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c69b60cc8331a7be3f7334d1287d