### PR TITLE
Add selectable color schemes

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const DEFAULTS = {
   endHour: 24,
   workTarget: 38.5,
   minutePx: 2,
+  theme: "bright-cold",
   categories: [
     { name: "Sleep", color: "#bef264" },
     { name: "Children", color: "#fca5a5" },
@@ -26,6 +27,7 @@ MINUTE_PX = state.minutePx || MINUTE_PX;
 init();
 
 function init() {
+  applyTheme();
   renderTimeColumn();
   renderDays();
   setupModals();
@@ -61,7 +63,8 @@ function loadState() {
       ...parsed,
       categories: parsed.categories || DEFAULTS.categories,
       blocks: parsed.blocks || [],
-      minutePx: parsed.minutePx || DEFAULTS.minutePx
+      minutePx: parsed.minutePx || DEFAULTS.minutePx,
+      theme: parsed.theme || DEFAULTS.theme
     };
   } catch {
     return structuredClone(DEFAULTS);
@@ -70,6 +73,10 @@ function loadState() {
 
 function saveState() {
   localStorage.setItem("weekly-planner-state-v1", JSON.stringify(state));
+}
+
+function applyTheme() {
+  document.body.dataset.theme = state.theme || "bright-cold";
 }
 
 function bindControls() {
@@ -311,6 +318,7 @@ function openSettingsModal() {
   $("#startHour").value = state.startHour;
   $("#endHour").value = state.endHour;
   $("#workTarget").value = state.workTarget;
+  $("#themeSelect").value = state.theme || "bright-cold";
   show($("#settingsModal"));
 }
 
@@ -318,6 +326,7 @@ function saveSettingsFromUI() {
   const sh = Number($("#startHour").value);
   const eh = Number($("#endHour").value);
   const wt = Number($("#workTarget").value);
+  const th = $("#themeSelect").value;
   if (!(sh>=0 && sh<24 && eh>0 && eh<=24 && eh>sh)) {
     alert("Please set valid day start/end hours.");
     return;
@@ -325,8 +334,10 @@ function saveSettingsFromUI() {
   state.startHour = sh;
   state.endHour = eh;
   state.workTarget = wt || 38.5;
+  state.theme = th;
   saveState();
   hide($("#settingsModal"));
+  applyTheme();
   renderTimeColumn();
   renderDays();
   renderBlocks();

--- a/index.html
+++ b/index.html
@@ -159,6 +159,18 @@
       </div>
     </div>
     <div class="row">
+      <label>Color scheme</label>
+      <select id="themeSelect">
+        <option value="bright-cold">Bright – Cool</option>
+        <option value="bright-warm">Bright – Warm</option>
+        <option value="bright-autumn">Bright – Autumn</option>
+        <option value="high-contrast">High Contrast</option>
+        <option value="dark-cold">Dark – Cool</option>
+        <option value="dark-warm">Dark – Warm</option>
+        <option value="dark-autumn">Dark – Autumn</option>
+      </select>
+    </div>
+    <div class="row">
       <label>Weekly work target (hours)</label>
       <input type="number" id="workTarget" step="0.5">
     </div>

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,62 @@
   --surface: #ffffff;
   --danger: #dc2626;
 }
+
+body[data-theme="bright-cold"] {
+  --primary: #2563eb;
+  --text: #1f2937;
+  --bg: #f3f4f6;
+  --surface: #ffffff;
+  --danger: #dc2626;
+}
+
+body[data-theme="bright-warm"] {
+  --primary: #ea580c;
+  --text: #1f2937;
+  --bg: #fff7ed;
+  --surface: #ffffff;
+  --danger: #b91c1c;
+}
+
+body[data-theme="bright-autumn"] {
+  --primary: #b45309;
+  --text: #1f2937;
+  --bg: #fffbeb;
+  --surface: #ffffff;
+  --danger: #c2410c;
+}
+
+body[data-theme="high-contrast"] {
+  --primary: #000000;
+  --text: #000000;
+  --bg: #ffffff;
+  --surface: #ffffff;
+  --danger: #ff0000;
+}
+
+body[data-theme="dark-cold"] {
+  --primary: #3b82f6;
+  --text: #f3f4f6;
+  --bg: #111827;
+  --surface: #1f2937;
+  --danger: #f87171;
+}
+
+body[data-theme="dark-warm"] {
+  --primary: #f97316;
+  --text: #f3f4f6;
+  --bg: #1c1917;
+  --surface: #292524;
+  --danger: #f87171;
+}
+
+body[data-theme="dark-autumn"] {
+  --primary: #d97706;
+  --text: #f3f4f6;
+  --bg: #1f1d1a;
+  --surface: #292524;
+  --danger: #f87171;
+}
 html, body {
   margin: 0;
   padding: 0;
@@ -65,7 +121,7 @@ aside { display: flex; flex-direction: column; gap: 16px; }
 }
 .panel.note ul { margin: 8px 0 0 20px; }
 .targetRow { display: flex; justify-content: space-between; margin-bottom: 6px; }
-.targetRow.small { font-size: 0.9rem; color: #374151; }
+.targetRow.small { font-size: 0.9rem; color: var(--text); }
 .progressOuter {
   width: 100%;
   height: 12px;
@@ -99,13 +155,13 @@ aside { display: flex; flex-direction: column; gap: 16px; }
   background: var(--bg);
   border-right: 1px solid #e5e7eb;
 }
-.timeLabel { height: 120px; padding: 2px 6px; font-size: 0.8rem; color: #6b7280; border-bottom: 1px dashed #eee; }
+.timeLabel { height: 120px; padding: 2px 6px; font-size: 0.8rem; color: var(--text); border-bottom: 1px dashed #eee; }
 
 .dayCol.day { position: relative; border-right: 1px solid #f1f5f9; }
 .dayCol.day::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 100%; background-image: linear-gradient(to bottom, rgba(0,0,0,0.04) 1px, transparent 1px); background-size: 100% 30px; pointer-events: none; }
 .dayCol.day:last-child { border-right: none; }
 
-.block { position: absolute; left: 6px; width: calc(100% - 12px); border-radius: 6px; color: #111; padding: 6px; font-size: 0.85rem; border: 1px solid rgba(0,0,0,0.1); box-shadow: 0 1px 2px rgba(0,0,0,0.06); overflow: auto; cursor: pointer; opacity: 0.9; }
+.block { position: absolute; left: 6px; width: calc(100% - 12px); border-radius: 6px; color: var(--text); padding: 6px; font-size: 0.85rem; border: 1px solid rgba(0,0,0,0.1); box-shadow: 0 1px 2px rgba(0,0,0,0.06); overflow: auto; cursor: pointer; opacity: 0.9; }
 .block .title { font-weight: 700; }
 .block .meta { font-size: 0.75rem; opacity: 0.9; }
 
@@ -115,7 +171,7 @@ aside { display: flex; flex-direction: column; gap: 16px; }
 
 .modal { position: fixed; inset: 0; background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; padding: 16px; }
 .modal.hidden { display: none; }
-.modalContent { background: #fff; width: 600px; max-width: 100%; border-radius: 12px; padding: 16px; border: 1px solid #e5e7eb; }
+.modalContent { background: var(--surface); width: 600px; max-width: 100%; border-radius: 12px; padding: 16px; border: 1px solid #e5e7eb; }
 .modal .row { margin-bottom: 10px; }
 .modal .row.two { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
 .modal .row label { display: block; font-weight: 600; margin-bottom: 4px; }
@@ -127,7 +183,7 @@ aside { display: flex; flex-direction: column; gap: 16px; }
 #categoryList .catItem { display: grid; grid-template-columns: 24px 1fr 80px 60px; gap: 8px; align-items: center; padding: 6px 0; border-bottom: 1px dashed #eee; }
 #categoryList .swatch { width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(0,0,0,0.15); }
 
-footer { text-align: center; color: #6b7280; padding: 10px; font-size: 0.85rem; }
+footer { text-align: center; color: var(--text); padding: 10px; font-size: 0.85rem; }
 
 @media (max-width: 1100px) {
   main { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- Add theme selector in settings modal
- Define bright, high-contrast, and dark color schemes with cold, warm, and autumn palettes
- Persist and apply selected color scheme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c9b3802c833196165bcca08c8d39